### PR TITLE
chore: track deriva-ml from git main (remove v1.45.0 version pin)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,12 @@ jupyter = ["ipykernel", "jupyter"]
 python-preference = "only-managed"
 
 [tool.uv.sources]
-# deriva-ml pinned to v1.45.0: restored DerivaML.user_list() (PR #282) and the
-# get_denormalized_as_dataframe(system_columns=...) opt-in (PR #283), both used
-# by EyeAI.image_tall.
-deriva-ml = { git = "https://github.com/informatics-isi-edu/deriva-ml", tag = "v1.45.0" }
+# deriva-ml tracks the latest from git main (no version pin) -- refresh with
+# `uv lock --upgrade-package deriva-ml`. (Recent must-have changes:
+# DerivaML.user_list() in PR #282 and get_denormalized_as_dataframe(
+# system_columns=...) in PR #283, both used by EyeAI.image_tall -- both are in
+# main.)
+deriva-ml = { git = "https://github.com/informatics-isi-edu/deriva-ml.git" }
 
 
 [tool.setuptools.package-data]

--- a/uv.lock
+++ b/uv.lock
@@ -792,8 +792,8 @@ dependencies = [
 
 [[package]]
 name = "deriva-ml"
-version = "1.45.0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-ml?tag=v1.45.0#5158d8f93043011f23b7ac2c0275479aadeb2a14" }
+version = "1.45.0.post1+g4d56677da"
+source = { git = "https://github.com/informatics-isi-edu/deriva-ml.git#4d56677dadd8a2ae55d936e89fb8662179b96908" }
 dependencies = [
     { name = "bdbag" },
     { name = "bump-my-version" },
@@ -865,7 +865,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deriva-ml", git = "https://github.com/informatics-isi-edu/deriva-ml?tag=v1.45.0" },
+    { name = "deriva-ml", git = "https://github.com/informatics-isi-edu/deriva-ml.git" },
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "matplotlib" },
     { name = "pandas" },


### PR DESCRIPTION
## Summary
Removes the fixed `tag = "v1.45.0"` version pin on deriva-ml in `[tool.uv.sources]`; the source now tracks the latest from git `main`:

```toml
deriva-ml = { git = "https://github.com/informatics-isi-edu/deriva-ml.git" }
```

Refresh with `uv lock --upgrade-package deriva-ml`. The features that motivated the prior pin (`DerivaML.user_list()` PR #282, `get_denormalized_as_dataframe(system_columns=...)` PR #283, both used by `EyeAI.image_tall`) are in `main`, so tracking `main` keeps them and picks up subsequent fixes automatically.

## Test Plan
- [x] `uv lock --upgrade-package deriva-ml` resolves cleanly (now `main` HEAD, no tag).
- [ ] CI / `uv sync` resolves; EyeAI.image_tall still imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)